### PR TITLE
Change config file parsing logic to allow '=' symbol in config values

### DIFF
--- a/pokeconfig.py
+++ b/pokeconfig.py
@@ -33,8 +33,10 @@ class Pokeconfig:
             logger.info('running locally, reading config from %s', config_path)
             with open(config_path, 'r') as fp:
                 for line in fp:
-                    parts = line.split('=')
-                    env[parts[0].strip()] = parts[1].strip()
+                    separatorIndex = line.index("=")
+                    key = line[:separatorIndex]
+                    value = line[separatorIndex + 1:]
+                    env[key] = value
         else:
             logger.info('running on heroku, reading config from environment')
             env = os.environ


### PR DESCRIPTION
Hello there!

While forking your project to make it work with Hipchat, I noticed I wasn't able to use a '=' in any of the values of the .env configuration file. I needed this as Hipchat webhook URLs contain an equal symbol.

So here's a PR with a fix for this issue. :)
